### PR TITLE
[DEBUG] shutdown only WR operations.

### DIFF
--- a/src/pomp_conn.c
+++ b/src/pomp_conn.c
@@ -1029,7 +1029,8 @@ int pomp_conn_close(struct pomp_conn *conn)
 	pomp_conn_clear_rx_fds(conn);
 
 	/* Properly shutdown the connection */
-	if (!conn->isdgram && shutdown(conn->fd, SHUT_RDWR) < 0) {
+	if (!conn->isdgram && !conn->is_shutdown
+			&& shutdown(conn->fd, SHUT_WR) < 0) {
 		if (errno != ENOTCONN)
 			POMP_LOG_FD_ERRNO("shutdown", conn->fd);
 	}
@@ -1095,7 +1096,7 @@ int pomp_conn_disconnect(struct pomp_conn *conn)
 	POMP_RETURN_ERR_IF_FAILED(!conn->isdgram, -ENOTCONN);
 
 	/* Shutting down connection will ultimately cause an EOF */
-	if (shutdown(conn->fd, SHUT_RDWR) < 0) {
+	if (shutdown(conn->fd, SHUT_WR) < 0) {
 		if (errno != ENOTCONN)
 			POMP_LOG_FD_ERRNO("shutdown", conn->fd);
 	}


### PR DESCRIPTION
- In pomp_conn_disconnect and pomp_conn_close,
      SHUT_RDWR was replaced by only SHUT_WR.
      Because on Windows, shutdown would hang after
      a pomp_conn_disconnect over a TCP/IP client
      connection (on GNU/Linux, it does not change
      anything).